### PR TITLE
(3D) memory mapped files

### DIFF
--- a/deepinv/datasets/patch_dataset.py
+++ b/deepinv/datasets/patch_dataset.py
@@ -1,6 +1,9 @@
 from deepinv.datasets.base import ImageDataset
 from deepinv.utils.decorators import _deprecated_alias
 
+from deepinv.utils.io_utils import load_npy
+
+import os
 
 class PatchDataset(ImageDataset):
     r"""
@@ -43,3 +46,16 @@ class PatchDataset(ImageDataset):
             patch = self.transform(patch)
 
         return patch.reshape(self.shape) if self.shape else patch
+
+
+'''class PatchDataset3D(ImageDataset):
+    def __init__(self, im_dir, patch_size=64, stride=32):
+        self.patch_size = patch_size
+        self.stride = stride
+        self.im_dir = im_dir
+
+        self.imgs = os.listdir(im_dir) # add a check here to ensure only nifti and/or npy files are included?
+        # self.shapes = [load_npy(os.path.join(im_dir, im), as_memmap=True).shape for im in self.imgs]
+        # to keep things as simple and close to the PatchDataset example, assume all files have same shape
+        shape = load_npy(os.path.join(im_dir, self.imgs[0]), as_memmap=True)'''
+

--- a/deepinv/datasets/patch_dataset.py
+++ b/deepinv/datasets/patch_dataset.py
@@ -84,7 +84,7 @@ class PatchDataset3D(ImageDataset):
         ih  = rem // self.patches_per_image_w
         iw  = rem %  self.patches_per_image_w
 
-        return load_np(fpath, start_coords=[id * self.stride, ih * self.stride, iw * self.stride], patch_size=self.patch_size)
+        return load_np(fpath, start_coords=[id * self.stride, ih * self.stride, iw * self.stride], patch_size=self.patch_size).unsqueeze(0)
     
 
 class AlternativePatchDataset3D(ImageDataset):
@@ -104,4 +104,4 @@ class AlternativePatchDataset3D(ImageDataset):
         shape = self.shapes[idx]
 
         # We use random here: need to make a fix for deterministic behaviour based on seed --> seed worker function, see torch reproducibility page
-        return load_np(fpath, start_coords=[random.randint(self.patch_size, shape[0] - self.patch_size), random.randint(self.patch_size, shape[1] - self.patch_size), random.randint(self.patch_size, shape[2] - self.patch_size)], patch_size=self.patch_size)
+        return load_np(fpath, start_coords=[random.randint(self.patch_size, shape[0] - self.patch_size), random.randint(self.patch_size, shape[1] - self.patch_size), random.randint(self.patch_size, shape[2] - self.patch_size)], patch_size=self.patch_size).unsqueeze(0)

--- a/deepinv/datasets/patch_dataset.py
+++ b/deepinv/datasets/patch_dataset.py
@@ -1,7 +1,7 @@
 from deepinv.datasets.base import ImageDataset
 from deepinv.utils.decorators import _deprecated_alias
 
-from deepinv.utils.io_utils import load_npy
+from deepinv.utils.io_utils import load_np
 
 import os
 
@@ -48,14 +48,39 @@ class PatchDataset(ImageDataset):
         return patch.reshape(self.shape) if self.shape else patch
 
 
-'''class PatchDataset3D(ImageDataset):
+class PatchDataset3D(ImageDataset):
     def __init__(self, im_dir, patch_size=64, stride=32):
         self.patch_size = patch_size
         self.stride = stride
         self.im_dir = im_dir
 
         self.imgs = os.listdir(im_dir) # add a check here to ensure only nifti and/or npy files are included?
-        # self.shapes = [load_npy(os.path.join(im_dir, im), as_memmap=True).shape for im in self.imgs]
+        # self.shapes = [load_np(os.path.join(im_dir, im), as_memmap=True).shape for im in self.imgs]
         # to keep things as simple and close to the PatchDataset example, assume all files have same shape
-        shape = load_npy(os.path.join(im_dir, self.imgs[0]), as_memmap=True)'''
+        D, H, W = load_np(os.path.join(im_dir, self.imgs[0]), as_memmap=True).shape
 
+        self.patches_per_image_d = (D - patch_size) // stride + 1
+        self.patches_per_image_h = (H - patch_size) // stride + 1
+        self.patches_per_image_w = (W - patch_size) // stride + 1
+
+        self.patches_per_image = (
+            self.patches_per_image_d
+            * self.patches_per_image_h
+            * self.patches_per_image_w
+        )
+
+    def __len__(self):
+        return len(self.imgs) * self.patches_per_image
+
+    def __getitem__(self, idx):
+        vol_idx = idx // self.patches_per_image
+        idx_in_vol = idx % self.patches_per_image
+        fpath = os.path.join(self.im_dir, self.imgs[vol_idx])
+
+        per_h_w = self.patches_per_image_h * self.patches_per_image_w
+        id = idx_in_vol // per_h_w
+        rem = idx_in_vol %  per_h_w
+        ih  = rem // self.patches_per_image_w
+        iw  = rem %  self.patches_per_image_w
+
+        return load_np(fpath, start_coords=[id * self.stride, ih * self.stride, iw * self.stride], patch_size=self.patch_size)

--- a/deepinv/datasets/patch_dataset.py
+++ b/deepinv/datasets/patch_dataset.py
@@ -103,5 +103,5 @@ class AlternativePatchDataset3D(ImageDataset):
         fpath = os.path.join(self.im_dir, self.imgs[idx])
         shape = self.shapes[idx]
 
-
+        # We use random here: need to make a fix for deterministic behaviour based on seed --> seed worker function, see torch reproducibility page
         return load_np(fpath, start_coords=[random.randint(self.patch_size, shape[0] - self.patch_size), random.randint(self.patch_size, shape[1] - self.patch_size), random.randint(self.patch_size, shape[2] - self.patch_size)], patch_size=self.patch_size)

--- a/deepinv/datasets/patch_dataset.py
+++ b/deepinv/datasets/patch_dataset.py
@@ -4,6 +4,7 @@ from deepinv.utils.decorators import _deprecated_alias
 from deepinv.utils.io_utils import load_np
 
 import os
+import random
 
 class PatchDataset(ImageDataset):
     r"""
@@ -84,3 +85,23 @@ class PatchDataset3D(ImageDataset):
         iw  = rem %  self.patches_per_image_w
 
         return load_np(fpath, start_coords=[id * self.stride, ih * self.stride, iw * self.stride], patch_size=self.patch_size)
+    
+
+class AlternativePatchDataset3D(ImageDataset):
+    def __init__(self, im_dir, patch_size=64):
+        self.patch_size = patch_size
+        self.im_dir = im_dir
+
+        self.imgs = os.listdir(im_dir) # add a check here to ensure only nifti and/or npy files are included?
+        self.shapes = [load_np(os.path.join(im_dir, im), as_memmap=True).shape for im in self.imgs]
+
+
+    def __len__(self):
+        return len(self.imgs)
+
+    def __getitem__(self, idx):
+        fpath = os.path.join(self.im_dir, self.imgs[idx])
+        shape = self.shapes[idx]
+
+
+        return load_np(fpath, start_coords=[random.randint(self.patch_size, shape[0] - self.patch_size), random.randint(self.patch_size, shape[1] - self.patch_size), random.randint(self.patch_size, shape[2] - self.patch_size)], patch_size=self.patch_size)

--- a/deepinv/models/dncnn.py
+++ b/deepinv/models/dncnn.py
@@ -39,21 +39,24 @@ class DnCNN(Denoiser):
         nf=64,
         pretrained="download",
         device="cpu",
+        dim=2
     ):
         super(DnCNN, self).__init__()
 
+        conv = {'2' :  nn.Conv2d, '3' : nn.Conv3d}[str(dim)]
+
         self.depth = depth
 
-        self.in_conv = nn.Conv2d(
+        self.in_conv = conv(
             in_channels, nf, kernel_size=3, stride=1, padding=1, bias=bias
         )
         self.conv_list = nn.ModuleList(
             [
-                nn.Conv2d(nf, nf, kernel_size=3, stride=1, padding=1, bias=bias)
+                conv(nf, nf, kernel_size=3, stride=1, padding=1, bias=bias)
                 for _ in range(self.depth - 2)
             ]
         )
-        self.out_conv = nn.Conv2d(
+        self.out_conv = conv(
             nf, out_channels, kernel_size=3, stride=1, padding=1, bias=bias
         )
 

--- a/deepinv/physics/noise.py
+++ b/deepinv/physics/noise.py
@@ -892,6 +892,24 @@ class SaltPepperNoise(NoiseModel):
         return y
 
 
+class RicianNoise(NoiseModel):
+    def __init__(
+        self,
+        sigma: Union[float, torch.Tensor] = 0.1,
+        rng: Optional[torch.Generator] = None,
+    ):
+        device = _infer_device([sigma, rng])
+        super().__init__(rng=rng)
+        sigma = self._float_to_tensor(sigma)
+        sigma = sigma.to(device)
+        self.register_buffer("sigma", sigma)
+
+    def forward(self, x, sigma=None):
+        self.update_parameters(sigma=sigma)
+        N1 = self.randn_like(x)
+        N2 = self.randn_like(x)
+        return torch.sqrt((self.sigma * N1 + x)**2 + (self.sigma * N2)**2)
+
 def _infer_device(
     device_held_candidates: Iterable, *, default: torch.device = torch.device("cpu")
 ) -> torch.device:

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -378,7 +378,7 @@ class Trainer:
 
         if train:
             self.loss_history = []
-        self.save_folder_im = f"{self.save_path}/images"
+        self.save_folder_im = None
 
         _ = self.load_model()
 

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -875,6 +875,14 @@ class Trainer:
             else:
                 x_nl = None
 
+            if len(x.shape) == 5: # N, C, H, W, D
+                if y.shape == x.shape: # else y would be ignored anyways
+                    y = y[:, :, :, y.shape[-1] // 2]
+                x = x[:, :, :, :, x.shape[-1] // 2]
+                x_net = x_net[:, :, :, :, x.shape[-1] // 2]
+                if x_nl:
+                    x_nl = x_nl[:, :, :, :, x_nl.shape[-1] // 2]
+
             imgs, titles, grid_image, caption = prepare_images(
                 x, y=y, x_net=x_net, x_nl=x_nl, rescale_mode=self.rescale_mode
             )

--- a/deepinv/training/trainer.py
+++ b/deepinv/training/trainer.py
@@ -378,7 +378,7 @@ class Trainer:
 
         if train:
             self.loss_history = []
-        self.save_folder_im = None
+        self.save_folder_im = f"{self.save_path}/images"
 
         _ = self.load_model()
 

--- a/examples/WIP/supervised_denoising.py
+++ b/examples/WIP/supervised_denoising.py
@@ -1,9 +1,42 @@
+import deepinv as dinv
+
 from deepinv.datasets.patch_dataset import AlternativePatchDataset3D
-from deepinv.physics.noise import GaussianNoise
+from deepinv.physics.noise import GaussianNoise, RicianNoise
 from deepinv.training import Trainer
 
+
+
 import os
+import torch
+
 
 if __name__ == '__main__':
     dataset = AlternativePatchDataset3D(os.environ['IXI_T1'])
-    physics = GaussianNoise(sigma=0.2)
+    physics = dinv.physics.forward.Physics(noise_model=RicianNoise(sigma=0.1))
+    dataloader = torch.utils.data.DataLoader(dataset, batch_size=4, shuffle=True)
+
+    model = dinv.models.dncnn.DnCNN(in_channels=1,
+                                    out_channels=1,
+                                    depth=4,
+                                    nf=16,
+                                    pretrained=None,
+                                    device='cuda:0',
+                                    dim=3)
+
+    trainer = Trainer(
+        model=model,
+        physics=physics,
+        optimizer=torch.optim.Adam(model.parameters(), lr=1e-3),
+        train_dataloader=dataloader,
+        epochs=50,
+        losses=dinv.loss.SupLoss(metric=dinv.metric.MSE()),
+        metrics=dinv.metric.PSNR(),
+        device='cuda:0',
+        show_progress_bar=True,
+        log_train_batch=True,
+        online_measurements=True
+    )
+
+    trainer.save_folder_im = './test_run'
+
+    trainer.train()

--- a/examples/WIP/supervised_denoising.py
+++ b/examples/WIP/supervised_denoising.py
@@ -37,6 +37,4 @@ if __name__ == '__main__':
         online_measurements=True
     )
 
-    trainer.save_folder_im = './test_run'
-
     trainer.train()

--- a/examples/WIP/supervised_denoising.py
+++ b/examples/WIP/supervised_denoising.py
@@ -1,0 +1,9 @@
+from deepinv.datasets.patch_dataset import AlternativePatchDataset3D
+from deepinv.physics.noise import GaussianNoise
+from deepinv.training import Trainer
+
+import os
+
+if __name__ == '__main__':
+    dataset = AlternativePatchDataset3D(os.environ['IXI_T1'])
+    physics = GaussianNoise(sigma=0.2)


### PR DESCRIPTION
WIP.

Will add an example training a super-resolution or denoising model on patches of MRI volumes. In this case, we will have a large number of volumes to extract patches from, so holding all in RAM like is done in PatchDataset would be infeasible. To avoid this 

Good situation to compare either using base `np.load` vs. `open_memmap`. Same thing can then be tested for nifti as well.