### PR TITLE
Patch 1

### DIFF
--- a/deepinv/loss/adversarial/base.py
+++ b/deepinv/loss/adversarial/base.py
@@ -102,7 +102,7 @@ class AdversarialLoss(Loss):
         self.optimizer_D = optimizer_D
         self.scheduler_D = scheduler_D
         self.num_D_steps = num_D_steps
-        if optimizer_D is None and scheduler_D is not None:
+        if optimizer_D is None and scheduler_D is not None:  # pragma: no cover
             raise ValueError(
                 "Discriminator scheduler requires discriminator optimizer to be passed."
             )
@@ -121,7 +121,7 @@ class AdversarialLoss(Loss):
         pred_fake = self.D(fake)
         return self.metric_gan(pred_fake, real=True) * self.weight_adv
 
-    def adversarial_discrim(self, real: Tensor, fake: Tensor):
+    def adversarial_discrim(self, real: Tensor, fake: Tensor) -> torch.Tensor:
         r"""Adversarial penalty mechanism in GAN discriminators.
 
         :param torch.Tensor real: image labelled as real, typically one originating from training set
@@ -137,7 +137,7 @@ class AdversarialLoss(Loss):
         return adv_loss_real + adv_loss_fake
 
     @contextmanager
-    def step_discrim(self, model: nn.Module = None):
+    def step_discrim(self, model: nn.Module):
         """
         Context manager that steps discriminator optimizer
         that wraps a loss calculation.
@@ -194,7 +194,12 @@ class AdversarialLoss(Loss):
         """
         raise NotImplementedError()
 
-    def load_model(self, filename, device=None, strict: bool = True) -> dict:
+    def load_model(
+        self,
+        filename: str | Path,
+        device: torch.device | str = None,
+        strict: bool = True,
+    ) -> dict:
         """Load discriminator from checkpoint.
 
         :param str, pathlib.Path filename: checkpoint filename.

--- a/deepinv/loss/adversarial/base.py
+++ b/deepinv/loss/adversarial/base.py
@@ -134,7 +134,7 @@ class AdversarialLoss(Loss):
         adv_loss_real = self.metric_gan(pred_real, real=True)
         adv_loss_fake = self.metric_gan(pred_fake, real=False)
 
-        return (adv_loss_real + adv_loss_fake) * self.weight_adv
+        return adv_loss_real + adv_loss_fake
 
     @contextmanager
     def step_discrim(self, model: nn.Module = None):

--- a/deepinv/loss/adversarial/base.py
+++ b/deepinv/loss/adversarial/base.py
@@ -159,7 +159,7 @@ class AdversarialLoss(Loss):
             def backward(loss: torch.Tensor):
                 if model.training:
                     self.log_loss_D_train.update(loss.item())
-                    loss.backward(retain_graph=True)
+                    loss.backward()
                 else:
                     self.log_loss_D_eval.update(loss.item())
 

--- a/deepinv/loss/adversarial/consistency.py
+++ b/deepinv/loss/adversarial/consistency.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import torch
 import torch.nn as nn
@@ -54,9 +54,7 @@ class SupAdversarialLoss(AdversarialLoss):
         >>> l.backward()
     """
 
-    def forward(
-        self, x: Tensor, x_net: Tensor, model: nn.Module = None, *args, **kwargs
-    ):
+    def forward(self, x: Tensor, x_net: Tensor, model: nn.Module, *args, **kwargs):
         r"""Forward pass for supervised adversarial generator loss.
 
         :param torch.Tensor x: ground truth image
@@ -119,7 +117,7 @@ class GPLoss(SupAdversarialLoss):
         model: nn.Module = None,
         *args,
         **kwargs,
-    ):
+    ) -> torch.Tensor:
         with self.step_discrim(model) as step:
             for _ in range(self.num_D_steps):
                 l = self.adversarial_discrim(x, x_net)
@@ -186,7 +184,7 @@ class UnsupAdversarialLoss(AdversarialLoss):
         metric_gan: DiscriminatorMetric = None,
         optimizer_D: torch.optim.Optimizer = None,
         scheduler_D: torch.optim.lr_scheduler.LRScheduler = None,
-        device="cpu",
+        device: torch.device | str = "cpu",
         **kwargs,
     ):
         super().__init__(
@@ -209,7 +207,7 @@ class UnsupAdversarialLoss(AdversarialLoss):
         model: nn.Module = None,
         *args,
         **kwargs,
-    ):
+    ) -> torch.Tensor:
         r"""Forward pass for unsupervised adversarial generator loss.
 
         :param torch.Tensor y: input measurement
@@ -318,7 +316,7 @@ class MultiOperatorUnsupAdversarialLoss(UnsupAdversarialLoss, MultiOperatorMixin
         scheduler_D: torch.optim.lr_scheduler.LRScheduler = None,
         physics_generator: PhysicsGenerator = None,
         dataloader: DataLoader = None,
-        device="cpu",
+        device: torch.device | str = "cpu",
         **kwargs,
     ):
         super().__init__(
@@ -352,10 +350,10 @@ class MultiOperatorUnsupAdversarialLoss(UnsupAdversarialLoss, MultiOperatorMixin
         x_net: Tensor,
         physics: Physics,
         model: nn.Module,
-        epoch=None,
+        epoch: Optional[int] = None,
         *args,
         **kwargs,
-    ):
+    ) -> torch.Tensor:
         self.reset_iter(epoch=epoch)
 
         # Step data and physics


### PR DESCRIPTION
- [x] Loss term used in optimizing the discriminator should not be multiplied by `self.weight_adv` (this coefficient is used to balance adversarial and other loss components for generator optimization, not relevant to discriminator optimization, see also [the note in BasicSR](https://github.com/XPixelGroup/BasicSR/blob/8d56e3a045f9fb3e1d8872f92ee4a4f07f886b0a/basicsr/losses/gan_loss.py#L112)
- [x] Remove `retain_graph=True` for loss backprop in `step_discrimin`. From my understanding, it should not be needed (at least for the `SupAdversarialLoss`).